### PR TITLE
simplify setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ To get the application started the following steps are required.
   $ bin/setup
   ```
 
-You can now start the application and give it a try at http://localhost:3000.
+You can now start the application and give it a try at
+[localhost:3000](http://localhost:3000).
 There's a demo user `user@example.com` with password `asdfasdf`.
 
   ```bash

--- a/README.md
+++ b/README.md
@@ -20,18 +20,23 @@ What Mykonote offers:
 
 To get the application started the following steps are required.
 
-* standard rails setup routine
-
-  ```bash
-  $ bundle
-  $ rake db:setup
-  ```
-
 * 3rd party javascripts and stylesheets are managed using bower
   ([bower-rails](https://github.com/rharriso/bower-rails)). You need to have
   npm and bower installed for this to work.
 
-  `$ rake bower:install`
+* standard rails setup routine
+
+  ```bash
+  $ bin/setup
+  ```
+
+You can now start the application and give it a try at http://localhost:3000.
+There's a demo user `user@example.com` with password `asdfasdf`.
+
+  ```bash
+  $ bin/rails server
+  ```
+
 
 ## License
 

--- a/bin/setup
+++ b/bin/setup
@@ -26,4 +26,7 @@ Dir.chdir APP_ROOT do
 
   puts "\n== Restarting application server =="
   system "touch tmp/restart.txt"
+
+  puts "\n== Install bower dependencies =="
+  system "bin/rake bower:install"
 end


### PR DESCRIPTION
The `bin/setup` script now comes as part of the default Rails offering.
This patch adds the bower setup to this script and updates the README.

The README now also contains some words about starting the development
server and the demo user.