### PR TITLE
Don't keep `:id` placeholder in pushed url

### DIFF
--- a/client/src/PushState.js
+++ b/client/src/PushState.js
@@ -1,3 +1,5 @@
+import { generatePath } from 'react-router';
+
 class PushState {
   constructor(match, history) {
     this.path = match.path;
@@ -9,7 +11,11 @@ class PushState {
   }
 
   setEdit(note) {
-    const url = `${this.path}/${note.uid}`;
+    let path = this.path;
+    if (!path.includes(':id')) {
+      path = `${path}/:id`;
+    }
+    const url = generatePath(path, { id: note.uid});
 
     if (this.history.location.pathname !== url) {
       this.history.push(url);


### PR DESCRIPTION
Reproducible steps:

- Click on a note --> the URL is ok (e.g. `/#/notes/f2850941-3e37-4e7d-aa19-a45b6a0e94e0`
- Click on another note --> the URL is broken (e.g. `/#/notes/:id/f2850941-3e37-4e7d-aa19-a45b6a0e94e0`)